### PR TITLE
[add]admin商品詳細ページ/itemモデル 税込価格計算メソッド（taxed_price）

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,6 +19,10 @@ class Item < ApplicationRecord
       "販売停止中"
     end
   end
-
+  
+  #税込価格
+  def taxed_price
+    (self.price * 1.10).round
+  end
 
 end

--- a/app/views/admin/items/_table.html.erb
+++ b/app/views/admin/items/_table.html.erb
@@ -18,7 +18,7 @@
         <% end %>
       </td>
       <!--X,XXX表記になるように、デフォで＄表記だったのでunit追記-->
-      <td><%= number_to_currency(item.price,unit: "¥",strip_insignificant_zeros: true) %></td>
+      <td><%= number_to_currency(item.price,unit: "",strip_insignificant_zeros: true) %></td>
       <td><%= item.genre.name %></td>
       <!--モデルで定義したメソッドから参照して表示するように-->
       <td>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -22,6 +22,5 @@
     <div class="d-flex justify-content-center">
       <%= paginate @items %>
     </div>
-
   </div>
 </div>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,7 +1,47 @@
 <div class="container">
+
+  <!--見出しの箱-->
   <div class="row">
-    <!--見出し-->
     <div class="col-4">
       <h3>商品詳細</h3>
     </div>
-    
+  </div>
+
+  <!--コンテンツの箱-->
+  <div class="row my-3">
+    <!--画像-->
+    <div class="col-4">
+      <%= image_tag @item.image, class: "w-100" %>
+    </div>
+
+    <!--詳細-->
+    <div class="ml-3 col-2">
+      <%= tag.div "商品名", class:"mb-3" %>
+      <%= tag.div "商品説明", class:"mb-3" %>
+      <%= tag.div "ジャンル", class:"mb-3" %>
+      <%= tag.div "税込価格(税抜価格)", class:"mb-3" %>
+      <%= tag.div "販売ステータス" %>
+    </div>
+    <div class="col-4">
+      <%= tag.div @item.name, class:"mb-3" %>
+      <%= tag.div @item.introduction, class:"mb-3" %>
+      <%= tag.div @item.genre.name, class:"mb-3" %>
+      <div class="mb-3">
+        <%= number_to_currency(@item.taxed_price,unit: "",strip_insignificant_zeros: true) %>
+        (<%= number_to_currency(@item.price,unit: "",strip_insignificant_zeros: true) %>) 円
+      </div>
+      <div class="mb-3">
+      <% if @item.is_active? %>
+        <span class="text-success font-weight-bold"><%= @item.sale_status %></span>
+      <% else %>
+        <span class="text-secondary font-weight-bold"><%= @item.sale_status %></span>
+      <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="text-center">
+    <%= link_to "編集する", edit_admin_item_path(@item),  class: "btn btn-success" %>
+  </div>
+
+</div>


### PR DESCRIPTION
円マーク消せたのでとりあえずワイヤーフレーム準拠に
詳細ページのレイアウトは勘弁してください