### PR TITLE
[Fix]admin側 注文履歴一覧、個人の注文履歴、微修正

### DIFF
--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -1,10 +1,5 @@
 <div class="container">
   <div class="row">
-    
-    <div class="col-auto">
-      <h3 class="bg-light">会員一覧</h3>
-    </div>
-    
     <div class="col-lg-12 col-md-10">
       <div class="d-flex justify-content-top mb-3">
         <h3 class="bg-light p-2">会員一覧</h3>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -39,7 +39,7 @@
             <%= link_to '編集する', edit_admin_customer_path(@cus), class: "btn btn-success" %>
           </button>
           <button class="btn">
-            <%= link_to '注文履歴一覧を見る', admin_root_path, class: "btn btn-primary" %>
+            <%= link_to '注文履歴一覧を見る', admin_orders_path(customer_id: @cus.id), class: "btn btn-primary" %>
           </button>
 
         </div>

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,13 +1,9 @@
 <div class="container">
-  
   <div class="row">
-    <div class="col-auto">
-      <h3>注文履歴一覧</h3>
-    </div>
-  </div>
-  
-  <div class="row">
-    <div class="col">
+    <div class="col-lg-12 col-md-10">
+      <div class="d-flex justify-content-top mb-3">
+        <h3 class="bg-light text-center w-fit-content p-2">注文履歴一覧</h3>
+      </div>
       <table class="table">
         <thead class="thead-light">
           <tr>
@@ -27,12 +23,12 @@
               </td>
               <td><%= order.name %></td>
               <td><%= order.order_details.sum(&:amount) %></td>
-              <td><%= order.status %></td>
+              <td><%= I18n.t("enums.order.status.#{order.status}") %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
+      <%= paginate @orders %>
     </div>
   </div>
-  <%= paginate @orders %>
 </div>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,13 +1,9 @@
 <div class="container">
-  
   <div class="row">
-    <div class="col-auto">
-      <h4><%= @customer.full_name %>さんの注文履歴</h4>
-    </div>
-  </div>
-  
-  <div class="row justify-content-center">
-    <div class="col-11">
+    <div class="col-lg-12 col-md-10">
+      <div class="d-flex justify-content-top mb-3">
+        <h3 class="bg-light text-center w-fit-content p-2"><%= @customer.full_name %>さんの注文履歴</h3>
+      </div>
       <table class="table">
         <thead class="thead-light">
           <tr>
@@ -25,12 +21,12 @@
                 <% end %>
               </td>
               <td><%= order.order_details.sum(&:amount) %></td>
-              <td><%= order.my_status %></td>
+              <td><%= I18n.t("enums.order.status.#{order.status}") %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
+      <%= paginate @orders %>
     </div>
   </div>
-  <%= paginate @orders %>
 </div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,8 +1,9 @@
 <div class="container">
-
   <div class="row">
-    <div class="offset-1 col-auto">
-      <h3>注文履歴詳細</h3>
+    <div class="col-lg-12 col-md-10">
+      <div class="d-flex justify-content-top mb-3">
+        <h3 class="bg-light text-center w-fit-content p-2">注文履歴詳細</h3>
+      </div>
     </div>
   </div>
 
@@ -88,7 +89,7 @@
         </tbody>
       </table>
     </div>
-    
+
     <!--金額テーブル-->
     <div class="col-lg-3 col-10 mt-auto mb-3">
       <table>


### PR DESCRIPTION
- admin側のページを、遷移したとき見出しの位置が揃うように修正
- 個人のページのリンク先が間違っていたので修正
- enum表示に修正