### PR TITLE
[update]注文情報確認画面でname,postcode,addressのどれかが空の場合弾くようにした。

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -36,6 +36,7 @@ class Public::OrdersController < ApplicationController
       redirect_to thanks_orders_path
     else
       @orders = current_customer.orders
+      flash.now[:alert] = "注文できませんでした。"
       render :index
 
     end
@@ -47,8 +48,15 @@ class Public::OrdersController < ApplicationController
     # 自身の住所/登録済み住所/新しい住所のどれが選ばれたかを確認。
     which_address = params[:order][:which_address]
     # 登録済み住所が選ばれた場合、そのidからデータを取得
-    if which_address == "1" && params[:order][:address_id].present?
-      chosen_address = Address.find(params[:order][:address_id])
+    if which_address == "1"
+      if params[:order][:address_id].present?
+        chosen_address = Address.find(params[:order][:address_id])
+      else
+        # 住所が選択されていない場合の処理
+        flash[:alert] = "登録された住所が見つかりませんでした。"
+        redirect_to new_order_path
+        return
+      end
     end
 
     @order = Order.new(params_order)
@@ -68,11 +76,14 @@ class Public::OrdersController < ApplicationController
       @order.name = chosen_address.name
       @order.postcode = chosen_address.postcode
       @order.address = chosen_address.address
-    else
-      # 住所が選択されていない場合の処理
-      flash[:alert] = "登録された住所が見つかりませんでした。"
-      redirect_to new_order_path
-      return
+    when 2 then
+      # nameかaddressかpostcodeが空の場合弾く
+      # もっと賢い書き方あるだろうけど分からない。
+      if @order.name == "" || @order.address == "" || @order.postcode == ""
+        flash[:alert] = "未記載の箇所があります。"
+        redirect_to new_order_path
+        return
+      end
     end
     # 新しい住所を選んだ場合、name, postcode, addressは送られてくるので何か処理する必要なし。
     @total_sum = @cart_items.sum(&:sum)

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -52,7 +52,7 @@ class Public::OrdersController < ApplicationController
       if params[:order][:address_id].present?
         chosen_address = Address.find(params[:order][:address_id])
       else
-        # 住所が選択されていない場合の処理
+        # 登録済み住所がない場合の処理
         flash[:alert] = "登録された住所が見つかりませんでした。"
         redirect_to new_order_path
         return

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -4,42 +4,43 @@
       <div class="d-flex justify-content-top mb-3">
         <h3 class="bg-light p-2">注文履歴一覧</h3>
       </div>
-    <table class='table table-borderd'>
-      <thead class="thead-light">
-        <tr>
-          <th>注文日</th>
-          <th>配送先</th>
-          <th>注文商品</th>
-          <th>支払金額</th>
-          <th>ステータス</th>
-          <th>注文詳細</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @orders.each do |od| %>
+      <table class='table table-borderd'>
+        <thead class="thead-light">
           <tr>
-            <td><%= od.created_at.strftime('%Y/%m/%d') %></td>
-            <td>
-              〒<%= od.postcode %><br>
-              <%= od.address %><br>
-              <%= od.name %>
-            </td>
-            <td>
-              <% od.items.each do |item| %>
-                <%= item.name %><br/>
-              <% end %>
-            </td>
-            <td>
-            </td>
-            <td><%= od.my_status %></td>
-            <td>
-              <button class="btn">
-                <%= link_to '表示する', order_path(od), class:"btn btn-primary" %>
-              </button>
-            </td>
+            <th>注文日</th>
+            <th>配送先</th>
+            <th>注文商品</th>
+            <th>支払金額</th>
+            <th>ステータス</th>
+            <th>注文詳細</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @orders.each do |od| %>
+            <tr>
+              <td><%= od.created_at.strftime('%Y/%m/%d') %></td>
+              <td>
+                〒<%= od.postcode %><br>
+                <%= od.address %><br>
+                <%= od.name %>
+              </td>
+              <td>
+                <% od.items.each do |item| %>
+                  <%= item.name %><br/>
+                <% end %>
+              </td>
+              <td>
+              </td>
+              <td><%= od.my_status %></td>
+              <td>
+                <button class="btn">
+                  <%= link_to '表示する', order_path(od), class:"btn btn-primary" %>
+                </button>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
会員側注文一覧の</div>が足りてなくて表示がバグってたので直したのと、インデントを足しました。